### PR TITLE
💥[FIX] #23 : 직관경기 기록에서 잘못된 예외처리 수정

### DIFF
--- a/src/main/java/com/example/ballog/domain/matchrecord/controller/MatchRecordController.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/controller/MatchRecordController.java
@@ -33,8 +33,8 @@ public class MatchRecordController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody MatchRecordRequest request) {
 
-        if (userDetails == null || userDetails.getUser().getRole() != Role.ADMIN) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        if (userDetails == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
         MatchRecordResponse response = matchRecordService.createRecord(request, userDetails.getUser());
@@ -50,8 +50,8 @@ public class MatchRecordController {
             @PathVariable("recordId") Long recordId,
             @RequestBody MatchResultRequest request) {
 
-        if (userDetails == null || userDetails.getUser().getRole() != Role.ADMIN) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        if (userDetails == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
         matchRecordService.updateResult(recordId, request.getResult());
@@ -66,7 +66,7 @@ public class MatchRecordController {
             @PathVariable("recordId") Long recordId) {
 
         if (userDetails == null) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
         MatchRecordResponse response = matchRecordService.getRecordDetail(recordId, userDetails.getUser());
@@ -81,7 +81,7 @@ public class MatchRecordController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         if (userDetails == null) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
         List<MatchRecordResponse> records = matchRecordService.getAllRecordsByUser(userDetails.getUser());
@@ -98,7 +98,7 @@ public class MatchRecordController {
             @PathVariable("recordId") Long recordId) {
 
         if (userDetails == null) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
         MatchRecord record = matchRecordService.findById(recordId);


### PR DESCRIPTION
## PR 작성 전 체크 리스트 (PR 생성시 해당 항목은 삭제 후 올려주세요!)

- merge 브랜치 확인할 것. **main으로 보내면 안 됨 :x:**

`close #{이슈 번호}`을 사용하면 PR이 merge되면 해당 이슈가 자동으로 닫힙니다.

## #⃣ 연관된 이슈

> #23 

## 📝 작업 내용

> 직관경기 기록과 같은 경우에는 ROLE이 ADMIN, USER 모두 작성이 가능한데 ADMIN일 경우에만 작성가능하도록 하는 ERRORCODE인 `ACCESS_DENIED`로 잘못 작성되어져서 해당 부분을 `UNAUTHORIZED`로 수정하는 작업을 수행

