### PR TITLE
✨[FEAT] #36 : 직관기록 - 경기결과 저장 기능 구현

### DIFF
--- a/src/main/java/com/example/ballog/domain/emotion/controller/EmotionController.java
+++ b/src/main/java/com/example/ballog/domain/emotion/controller/EmotionController.java
@@ -1,7 +1,6 @@
 package com.example.ballog.domain.emotion.controller;
 
 import com.example.ballog.domain.emotion.dto.request.EmotionEnrollRequest;
-import com.example.ballog.domain.emotion.dto.request.EmotionRequest;
 import com.example.ballog.domain.emotion.dto.response.EmotionEnrollResponse;
 import com.example.ballog.domain.emotion.dto.response.EmotionResponse;
 import com.example.ballog.domain.emotion.service.EmotionService;

--- a/src/main/java/com/example/ballog/domain/match/controller/MatchesController.java
+++ b/src/main/java/com/example/ballog/domain/match/controller/MatchesController.java
@@ -89,7 +89,8 @@ public class MatchesController {
     @ApiErrorResponses({
             @ApiErrorResponse(ErrorCode.UNAUTHORIZED),
             @ApiErrorResponse(ErrorCode.ACCESS_DENIED),
-            @ApiErrorResponse(ErrorCode.MATCH_NOT_FOUND)
+            @ApiErrorResponse(ErrorCode.MATCH_NOT_FOUND),
+            @ApiErrorResponse(ErrorCode.MATCH_RESULT_FORMAT_INVALID)
     })
     public ResponseEntity<BasicResponse<MatchesResponse>> updateMatch(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/ballog/domain/match/repository/MatchesRepository.java
+++ b/src/main/java/com/example/ballog/domain/match/repository/MatchesRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface MatchesRepository extends JpaRepository<Matches, Long> {
     List<Matches> findAllByMatchesDate(LocalDate date);
+
 }

--- a/src/main/java/com/example/ballog/domain/match/service/MatchesService.java
+++ b/src/main/java/com/example/ballog/domain/match/service/MatchesService.java
@@ -1,18 +1,24 @@
 package com.example.ballog.domain.match.service;
 
+import com.example.ballog.domain.login.entity.BaseballTeam;
 import com.example.ballog.domain.match.dto.request.MatchesRequest;
 import com.example.ballog.domain.match.dto.response.MatchesGroupedResponse;
 import com.example.ballog.domain.match.dto.response.MatchesResponse;
 import com.example.ballog.domain.match.entity.Matches;
 import com.example.ballog.domain.match.repository.MatchesRepository;
+import com.example.ballog.domain.matchrecord.entity.MatchRecord;
+import com.example.ballog.domain.matchrecord.entity.Result;
+import com.example.ballog.domain.matchrecord.repository.MatchRecordRepository;
 import com.example.ballog.global.common.exception.CustomException;
 import com.example.ballog.global.common.exception.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -21,6 +27,7 @@ import java.util.stream.Collectors;
 public class MatchesService {
 
     private final MatchesRepository matchesRepository;
+    private final MatchRecordRepository matchRecordRepository;
 
     public MatchesResponse createMatches(MatchesRequest request){
         Matches match = new Matches();
@@ -70,6 +77,7 @@ public class MatchesService {
         return MatchesResponse.from(match);
     }
 
+    @Transactional
     public MatchesResponse updateMatch(Long matchId, MatchesRequest request) {
         Matches match = matchesRepository.findById(matchId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MATCH_NOT_FOUND));
@@ -94,8 +102,52 @@ public class MatchesService {
             match.setStadium(request.getStadium());
         }
 
-        Matches updatedMatch = matchesRepository.save(match);
-        return MatchesResponse.from(updatedMatch);
+        boolean resultChanged = false;
+        if (request.getMatchesResult() != null &&
+                !Objects.equals(match.getMatchesResult(), request.getMatchesResult())) {
+            resultChanged = true;
+            match.setMatchesResult(request.getMatchesResult());
+        }
+
+        if (resultChanged) {
+            updateMatchRecordsResult(match);
+        }
+
+        return MatchesResponse.from(matchesRepository.save(match));
+    }
+
+    private void updateMatchRecordsResult(Matches match) {
+        List<MatchRecord> records = matchRecordRepository.findAllByMatches_MatchesId(match.getMatchesId());
+
+        for (MatchRecord record : records) {
+            Result result = determineResult(
+                    match.getMatchesResult(),
+                    match.getHomeTeam(),
+                    match.getAwayTeam(),
+                    record.getBaseballTeam()
+            );
+            record.setResult(result);
+        }
+        matchRecordRepository.saveAll(records);
+    }
+
+    private Result determineResult(String matchResult, BaseballTeam homeTeam, BaseballTeam awayTeam, BaseballTeam userTeam) {
+        String[] scores = matchResult.split(":");
+        if (scores.length != 2) {
+            throw new CustomException(ErrorCode.MATCH_RESULT_FORMAT_INVALID);
+        }
+
+        int homeScore = Integer.parseInt(scores[0].trim());
+        int awayScore = Integer.parseInt(scores[1].trim());
+
+        if (homeScore == awayScore) {
+            return Result.DRAW;
+        }
+
+        boolean userIsHome = userTeam == homeTeam;
+        boolean userWon = (userIsHome && homeScore > awayScore) || (!userIsHome && awayScore > homeScore);
+
+        return userWon ? Result.WIN : Result.LOSS;
     }
 
 
@@ -105,10 +157,5 @@ public class MatchesService {
 
         matchesRepository.delete(match);
     }
-
-
-
-
-
 
 }

--- a/src/main/java/com/example/ballog/domain/matchrecord/controller/MatchRecordController.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/controller/MatchRecordController.java
@@ -1,6 +1,5 @@
 package com.example.ballog.domain.matchrecord.controller;
 
-import com.example.ballog.domain.login.entity.Role;
 import com.example.ballog.domain.login.security.CustomUserDetails;
 import com.example.ballog.domain.matchrecord.dto.request.MatchRecordRequest;
 import com.example.ballog.domain.matchrecord.dto.request.MatchResultRequest;
@@ -21,8 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/example/ballog/domain/matchrecord/entity/MatchRecord.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/entity/MatchRecord.java
@@ -37,8 +37,5 @@ public class MatchRecord {
     private BaseballTeam baseballTeam;
 
     @Column(nullable = false)
-    private boolean autoProcessed = false;
-
-    @Column(nullable = false)
     private String defaultImageUrl;
 }

--- a/src/main/java/com/example/ballog/domain/matchrecord/entity/Result.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/entity/Result.java
@@ -3,7 +3,5 @@ package com.example.ballog.domain.matchrecord.entity;
 public enum Result {
     WIN,
     LOSS,
-    DRAW,
-    SKIP;
-
+    DRAW;
 }

--- a/src/main/java/com/example/ballog/domain/matchrecord/repository/MatchRecordRepository.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/repository/MatchRecordRepository.java
@@ -1,6 +1,7 @@
 package com.example.ballog.domain.matchrecord.repository;
 
 import com.example.ballog.domain.login.entity.User;
+import com.example.ballog.domain.match.entity.Matches;
 import com.example.ballog.domain.matchrecord.entity.MatchRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,6 +11,8 @@ import java.util.List;
 @Repository
 public interface MatchRecordRepository extends JpaRepository<MatchRecord, Long> {
     long countByUser(User user);
-    List<MatchRecord> findAllByResultIsNull();
     List<MatchRecord> findAllByUserOrderByMatchrecordIdDesc(User user);
+    List<MatchRecord> findAllByMatches_MatchesId(Long matchesId);
+
+
 }

--- a/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
@@ -30,12 +30,14 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class MatchRecordService {
+
+    @Value("${app.default-image-url}")
+    private String defaultImageUrl;
     private final MatchesRepository matchesRepository;
     private final MatchRecordRepository matchRecordRepository;
     private final EmotionRepository emotionRepository;
     private final ImageRepository imageRepository;
-    @Value("${app.default-image-url}")
-    private String defaultImageUrl;
+
 
     @Transactional
     public MatchRecordResponse createRecord(MatchRecordRequest request, User user) {
@@ -77,25 +79,6 @@ public class MatchRecordService {
         matchRecord.setResult(result);
     }
 
-    @Scheduled(fixedDelay = 60 * 60 * 1000)
-    @Transactional
-    public void autoUnfinishedRecords() {
-        LocalDateTime now = LocalDateTime.now();
-
-        List<MatchRecord> pendingRecords = matchRecordRepository.findAllByResultIsNull();
-
-        for (MatchRecord record : pendingRecords) {
-            Matches match = record.getMatches();
-            LocalDateTime matchDateTime = LocalDateTime.of(
-                    match.getMatchesDate(),
-                    match.getMatchesTime()
-            );
-
-            if (matchDateTime.plusHours(8).isBefore(now)) {
-                record.setResult(Result.SKIP);
-            }
-        }
-    }
 
     @Transactional(readOnly = true)
     public MatchRecordDetailResponse getRecordDetail(Long recordId, User currentUser) {
@@ -144,9 +127,6 @@ public class MatchRecordService {
                 .imageList(imageList)
                 .build();
     }
-
-
-
 
     @Transactional(readOnly = true)
     public MatchRecordListResponse getAllRecordsByUser(User user) {

--- a/src/main/java/com/example/ballog/global/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/example/ballog/global/common/exception/enums/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
 
     //MATCH
     MATCH_NOT_FOUND(408,"MATCH001","해당 경기 정보를 찾을 수 없습니다."),
+    MATCH_RESULT_FORMAT_INVALID(413,"MATCH002", "경기 결과 형식이 잘못되었습니다. 예: 5:3"),
+
 
     //MATCH_RECORD
     NOT_FOUND_RECORD(408,"RECORD001","해당 직관기록을 찾을 수 없습니다."),


### PR DESCRIPTION
## PR 작성 전 체크 리스트 (PR 생성시 해당 항목은 삭제 후 올려주세요!)

- merge 브랜치 확인할 것. **main으로 보내면 안 됨 :x:**

`close #{이슈 번호}`을 사용하면 PR이 merge되면 해당 이슈가 자동으로 닫힙니다.

## #⃣ 연관된 이슈

> #36 

## 📝 작업 내용
기획 수정으로 인한 직관기록 -> 경기 결과 저장 기능 수정

[수정된 사항]
1.경기 결과 자동 저장 -  8시간 이후에 경기결과 미입력시 자동 저장하는 기능 삭제
2. 유저가 직접 직관기록에 대한 결과 작성하는 로직 삭제 
➡️ 경기결과가 등록시 유저의 응원팀에 따라 `WIN`, `LOSE`, `DRAW` 결과가 자동으로 저장되도록 구현
