### PR TITLE
✨[FEAT] #60:  감정 타임라인 기능 구현

### DIFF
--- a/src/main/java/com/example/ballog/domain/matchrecord/dto/response/EmotionGroupInfo.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/dto/response/EmotionGroupInfo.java
@@ -1,0 +1,17 @@
+package com.example.ballog.domain.matchrecord.dto.response;
+
+import com.example.ballog.domain.emotion.entity.EmotionType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EmotionGroupInfo {
+    private LocalDateTime groupStart; // 1분 단위로 감정 그룹핑
+    private EmotionType emotionType;
+    private long count;
+}

--- a/src/main/java/com/example/ballog/domain/matchrecord/dto/response/ImageInfo.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/dto/response/ImageInfo.java
@@ -1,0 +1,14 @@
+package com.example.ballog.domain.matchrecord.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ImageInfo {
+    private String imageUrl;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/ballog/domain/matchrecord/dto/response/MatchRecordDetailResponse.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/dto/response/MatchRecordDetailResponse.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -29,11 +28,5 @@ public class MatchRecordDetailResponse {
     private double negativeEmotionPercent;
     private String defaultImageUrl;
     private List<ImageInfo> imageList;
-
-    @Getter
-    @Builder
-    public static class ImageInfo {
-        private String imageUrl;
-        private LocalDateTime createdAt;
-    }
+    private List<EmotionGroupInfo> emotionGroupList;
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #60 
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 직관상세조회 -> 감정 타임라인 기능 추가
-> 감정을 1분단위로 그룹핑하여 같은 감정이 3회 이상 클릭시 조회되도록 기능 구현

