### PR TITLE
✨[FEAT] #62 : matchId 기반 직관 기록 상세 조회 API 추가

### DIFF
--- a/src/main/java/com/example/ballog/domain/matchrecord/controller/MatchRecordController.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/controller/MatchRecordController.java
@@ -69,7 +69,7 @@ public class MatchRecordController {
     }
 
     @GetMapping("/{recordId}")
-    @Operation(summary = "직관 기록 상세 조회", description = "특정 직관 기록 상세 정보 조회")
+    @Operation(summary = "직관 기록 상세 조회-recordId 기반", description = "특정 직관 기록 상세 정보 조회")
     @ApiErrorResponses({
             @ApiErrorResponse(ErrorCode.UNAUTHORIZED),
             @ApiErrorResponse(ErrorCode.NOT_FOUND_RECORD),
@@ -88,6 +88,28 @@ public class MatchRecordController {
         return ResponseEntity.ok(
                 BasicResponse.ofSuccess("직관 기록 상세 조회 성공",  response));
     }
+
+    @GetMapping("/{matchId}/match")
+    @Operation(summary = "직관 기록 상세 조회-matchId 기반", description = "특정 경기(matchId)에 대한 사용자의 직관 기록 상세 정보 조회")
+    @ApiErrorResponses({
+            @ApiErrorResponse(ErrorCode.UNAUTHORIZED),
+            @ApiErrorResponse(ErrorCode.NOT_FOUND_RECORD),
+            @ApiErrorResponse(ErrorCode.RECORD_NOT_OWNED)
+    })
+    public ResponseEntity<BasicResponse<MatchRecordDetailResponse>> getRecordDetailByMatchId(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("matchId") Long matchId) {
+
+        if (userDetails == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        MatchRecordDetailResponse response = matchRecordService.getRecordDetailByMatchId(matchId, userDetails.getUser());
+
+        return ResponseEntity.ok(
+                BasicResponse.ofSuccess("직관 기록 상세 조회 성공 (matchId 기반)", response));
+    }
+
 
     @GetMapping
     @Operation(summary = "전체 직관 기록 목록 조회", description = "로그인 사용자 본인의 모든 직관 기록 조회(= 직관로그 페이지)")

--- a/src/main/java/com/example/ballog/domain/matchrecord/repository/MatchRecordRepository.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/repository/MatchRecordRepository.java
@@ -6,12 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MatchRecordRepository extends JpaRepository<MatchRecord, Long> {
     long countByUser(User user);
     List<MatchRecord> findAllByUserOrderByMatchrecordIdDesc(User user);
     List<MatchRecord> findAllByMatches_MatchesId(Long matchesId);
+    Optional<MatchRecord> findByMatches_MatchesIdAndUser_UserId(Long matchesId, Long userId);
 
 
 }

--- a/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
@@ -165,6 +165,14 @@ public class MatchRecordService {
                 .build();
     }
 
+    public MatchRecordDetailResponse getRecordDetailByMatchId(Long matchId, User currentUser) {
+        MatchRecord record = matchRecordRepository.findByMatches_MatchesIdAndUser_UserId(matchId, currentUser.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECORD));
+
+        return getRecordDetail(record.getMatchrecordId(), currentUser);
+    }
+
+
     @Transactional(readOnly = true)
     public MatchRecordListResponse getAllRecordsByUser(User user) {
         List<MatchRecord> records = matchRecordRepository.findAllByUserOrderByMatchrecordIdDesc(user);


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #62 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 직관기록 상세 조회에  matchId 기반 직관 기록 상세 조회 API 추가
