### PR TITLE
💥[FIX] 직관경기 기록 삭제 시 연관관계 오류 수정

### DIFF
--- a/src/main/java/com/example/ballog/domain/emotion/repository/EmotionRepository.java
+++ b/src/main/java/com/example/ballog/domain/emotion/repository/EmotionRepository.java
@@ -21,4 +21,6 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
     @Modifying
     @Query("delete from Emotion e where e.matchRecord.user.userId = :userId")
     void deleteAllByUserUserId(@Param("userId") Long userId);
+
+    void deleteAllByMatchRecord(MatchRecord matchRecord);
 }

--- a/src/main/java/com/example/ballog/domain/login/entity/BaseballTeam.java
+++ b/src/main/java/com/example/ballog/domain/login/entity/BaseballTeam.java
@@ -1,7 +1,7 @@
 package com.example.ballog.domain.login.entity;
 
 public enum BaseballTeam {
-    DOOSAN_BEARS("두산 베어스"),
+    DOOSAN_BEARS("두산 베어스"), 
     LOTTE_GIANTS("롯데 자이언츠"),
     SAMSUNG_LIONS("삼성 라이온즈"),
     KIWOOM_HEROES("키움 히어로즈"),

--- a/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
@@ -234,6 +234,7 @@ public class MatchRecordService {
     @Transactional
     public void deleteRecord(Long recordId) {
         MatchRecord record = findById(recordId);
+        emotionRepository.deleteAllByMatchRecord(record);
         matchRecordRepository.delete(record);
     }
 


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #97 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

직관 경기 기록 삭제 시 emotion과 연관관계로 인한 오류 발생 해결 