### PR TITLE
[FIX] : matchRecord 삭제 시 외래키 문제 해결

### DIFF
--- a/src/main/java/com/example/ballog/domain/Image/respository/ImageRepository.java
+++ b/src/main/java/com/example/ballog/domain/Image/respository/ImageRepository.java
@@ -20,4 +20,5 @@ public interface ImageRepository  extends JpaRepository<Image, Long> {
     @Query("delete from Image i where i.matchRecord.user.userId = :userId")
     void deleteAllByUserUserId(@Param("userId") Long userId);
 
+    void deleteAllByMatchRecord(MatchRecord record);
 }

--- a/src/main/java/com/example/ballog/domain/login/service/AppleOAuthService.java
+++ b/src/main/java/com/example/ballog/domain/login/service/AppleOAuthService.java
@@ -169,7 +169,6 @@ public class AppleOAuthService {
 
         return jwt.serialize();
     }
-
     public byte[] getPrivateKey() throws Exception {
         if (appleKeyPath == null || appleKeyPath.isEmpty()) {
             throw new Exception("애플 개인 키가 설정되어 있지 않습니다.");
@@ -187,6 +186,7 @@ public class AppleOAuthService {
 
         return Base64.getDecoder().decode(privateKeyPem);
     }
+
 
 
     public ECPrivateKey getECPrivateKey(byte[] privateKeyBytes) throws Exception {

--- a/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
@@ -240,8 +240,8 @@ public class MatchRecordService {
     public void deleteRecord(Long recordId) {
         MatchRecord record = findById(recordId);
         emotionRepository.deleteAllByMatchRecord(record);
+        imageRepository.deleteAllByMatchRecord(record);
         matchRecordRepository.delete(record);
     }
-
 
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

matchRecord 삭제할때 image 관련해서 외래키 문제 발생으로 인한 코드 수정
