### PR TITLE
✨[FEAT]  #122 : 이미지 삭제 로직 & 토큰 재발급 로직 수정

### DIFF
--- a/src/main/java/com/example/ballog/domain/Image/respository/ImageRepository.java
+++ b/src/main/java/com/example/ballog/domain/Image/respository/ImageRepository.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 public interface ImageRepository  extends JpaRepository<Image, Long> {
     Optional<Image> findFirstByMatchRecordOrderByCreatedAtAsc(MatchRecord matchRecord);
     List<Image> findByMatchRecord(MatchRecord matchRecord);
+    List<Image> findAllByMatchRecord(MatchRecord matchRecord);
     @Modifying
     @Query("delete from Image i where i.matchRecord.user.userId = :userId")
     void deleteAllByUserUserId(@Param("userId") Long userId);

--- a/src/main/java/com/example/ballog/domain/Image/service/S3Service.java
+++ b/src/main/java/com/example/ballog/domain/Image/service/S3Service.java
@@ -79,5 +79,24 @@ public class S3Service {
     public String getAccessibleUrl(String fileName) {
         return "https://" + bucket + ".s3." + region + ".amazonaws.com/images/" + fileName;
     }
+
+    public void deleteFileFromS3(String imageUrl) { //s3 버킷에 올라간 이미지 삭제
+        if (imageUrl == null || imageUrl.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_URL);
+        }
+
+        String fileName = extractFileNameFromUrl(imageUrl);
+
+        String s3Key = "images/" + fileName;
+
+        try {
+            amazonS3.deleteObject(bucket, s3Key);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.S3_DELETE_FAILED); // 필요 시 ErrorCode에 정의
+        }
+    }
+
+
+
 }
 

--- a/src/main/java/com/example/ballog/domain/login/service/UserService.java
+++ b/src/main/java/com/example/ballog/domain/login/service/UserService.java
@@ -101,17 +101,12 @@ public class UserService {
     }
 
 
-    public void updateUser(User user) {
-        userRepository.save(user);
-    }
-
     public ResponseEntity<BasicResponse<Object>> processLogin(User user, boolean isSignup) {
-        String refreshToken = tokenService.getRefreshToken(user);
 
-        if (refreshToken == null || refreshToken.isEmpty()) { //새로 회원가입하는 유저 or 로그아웃하고 로그인하는 유저
-            refreshToken = tokenService.createRefreshToken(user);
-            tokenService.saveRefreshToken(user, refreshToken);
-        }
+
+        String refreshToken = tokenService.createRefreshToken(user); //회원가입 -> 뒤로가기 -> 재로그인경우를 고려해 무조건 새로 발급받은걸로 저장
+        tokenService.saveRefreshToken(user, refreshToken);
+
 
         String accessToken = tokenService.renewAccessToken(refreshToken);
 

--- a/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/service/MatchRecordService.java
@@ -1,6 +1,8 @@
 package com.example.ballog.domain.matchrecord.service;
 
+import com.example.ballog.domain.Image.entity.Image;
 import com.example.ballog.domain.Image.respository.ImageRepository;
+import com.example.ballog.domain.Image.service.S3Service;
 import com.example.ballog.domain.emotion.entity.Emotion;
 import com.example.ballog.domain.emotion.entity.EmotionType;
 import com.example.ballog.domain.emotion.repository.EmotionRepository;
@@ -37,6 +39,7 @@ public class MatchRecordService {
     private final MatchRecordRepository matchRecordRepository;
     private final EmotionRepository emotionRepository;
     private final ImageRepository imageRepository;
+    private final S3Service s3Service;
 
 
     @Transactional
@@ -239,6 +242,13 @@ public class MatchRecordService {
     @Transactional
     public void deleteRecord(Long recordId) {
         MatchRecord record = findById(recordId);
+
+        List<Image> images = imageRepository.findAllByMatchRecord(record);
+
+        for (Image image : images) {
+            s3Service.deleteFileFromS3(image.getImageUrl());
+        }
+
         emotionRepository.deleteAllByMatchRecord(record);
         imageRepository.deleteAllByMatchRecord(record);
         matchRecordRepository.delete(record);

--- a/src/main/java/com/example/ballog/global/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/example/ballog/global/common/exception/enums/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     FILE_UPLOAD_FAIL(410, "IMAGE001", "사진 업로드 실패입니다."),
     INVALID_FILE_EXTENSION(411,"FILE_001", "유효하지 않은 파일 형식입니다."),
     UNSUPPORTED_FILE_EXTENSION(411,"FILE_002", "지원하지 않는 파일 확장자입니다."),
+    S3_DELETE_FAILED(415, "IMAGE002", "AWS S3 이미지 파일 삭제에 실패했습니다."),
     INVALID_URL(412, "URL001", "유효하지 않은 URL입니다."),
 
     //ALERT


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #122 

## 📝 작업 내용

1. 직관기록 삭제 시 -> 이미지 삭제 로직에서 db에서만 삭제하고 aws-s3에서는 삭제하는 로직을 안만들어서 코드 수정진행
2. 로그아웃 안하고 소셜 재로그인 시 새로 발급받은 토큰을 저장 X 
   -> 로그아웃안하고 로그인하는 경우도 발생하기에 무조건 새로 재발급된 토큰을 저장하도록 로직 수정