### PR TITLE
[Feat] 야구 경기 일정관련 admin 기능 구현

### DIFF
--- a/src/main/java/com/example/ballog/domain/match/dto/request/MatchesRequest.java
+++ b/src/main/java/com/example/ballog/domain/match/dto/request/MatchesRequest.java
@@ -2,6 +2,7 @@ package com.example.ballog.domain.match.dto.request;
 
 import com.example.ballog.domain.login.entity.BaseballTeam;
 import com.example.ballog.domain.match.entity.Stadium;
+import com.example.ballog.domain.match.entity.Status;
 import lombok.Data;
 
 import java.time.LocalDate;
@@ -14,4 +15,5 @@ public class MatchesRequest {
     private BaseballTeam awayTeam;
     private Stadium stadium;
     private String matchesResult;
+    private Status status;
 }

--- a/src/main/java/com/example/ballog/domain/match/dto/response/MatchesGroupedResponse.java
+++ b/src/main/java/com/example/ballog/domain/match/dto/response/MatchesGroupedResponse.java
@@ -3,6 +3,7 @@ package com.example.ballog.domain.match.dto.response;
 import com.example.ballog.domain.login.entity.BaseballTeam;
 import com.example.ballog.domain.match.entity.Matches;
 import com.example.ballog.domain.match.entity.Stadium;
+import com.example.ballog.domain.match.entity.Status;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -18,6 +19,7 @@ public class MatchesGroupedResponse {
     private BaseballTeam awayTeam;
     private Stadium stadium;
     private String matchesResult;
+    private Status status;
 
     public static MatchesGroupedResponse from(Matches match) {
         return new MatchesGroupedResponse(
@@ -26,7 +28,8 @@ public class MatchesGroupedResponse {
                 match.getHomeTeam(),
                 match.getAwayTeam(),
                 match.getStadium(),
-                match.getMatchesResult()
+                match.getMatchesResult(),
+                match.getStatus()
         );
     }
 }

--- a/src/main/java/com/example/ballog/domain/match/dto/response/MatchesResponse.java
+++ b/src/main/java/com/example/ballog/domain/match/dto/response/MatchesResponse.java
@@ -3,6 +3,7 @@ package com.example.ballog.domain.match.dto.response;
 import com.example.ballog.domain.login.entity.BaseballTeam;
 import com.example.ballog.domain.match.entity.Matches;
 import com.example.ballog.domain.match.entity.Stadium;
+import com.example.ballog.domain.match.entity.Status;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -20,6 +21,7 @@ public class MatchesResponse {
     private BaseballTeam awayTeam;
     private Stadium stadium;
     private String matchesResult;
+    private Status status;
 
     public static MatchesResponse from(Matches match) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
@@ -31,7 +33,8 @@ public class MatchesResponse {
                 match.getHomeTeam(),
                 match.getAwayTeam(),
                 match.getStadium(),
-                match.getMatchesResult()
+                match.getMatchesResult(),
+                match.getStatus()
         );
     }
 }

--- a/src/main/java/com/example/ballog/domain/match/entity/Matches.java
+++ b/src/main/java/com/example/ballog/domain/match/entity/Matches.java
@@ -43,9 +43,22 @@ public class Matches {
     @Column(name = "matches_result", length = 100)
     private String matchesResult;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Status status;
+
     @Column(name = "start_alert_scheduled", nullable = false)
     private boolean startAlertScheduled = false;
 
     @Column(name = "in_game_alert_scheduled", nullable = false)
     private boolean inGameAlertScheduled = false;
+
+    @PrePersist
+    public void prePersist() {
+        if (status == null) {
+            status = Status.DEFAULT;
+        }
+    }
+
+
 }

--- a/src/main/java/com/example/ballog/domain/match/entity/Status.java
+++ b/src/main/java/com/example/ballog/domain/match/entity/Status.java
@@ -1,0 +1,10 @@
+package com.example.ballog.domain.match.entity;
+
+public enum Status {
+    SCHEDULED,   // 예정
+    IN_PROGRESS, // 진행중
+    COMPLETED,   // 종료
+    CANCELED;    // 취소
+
+    public static final Status DEFAULT = SCHEDULED;
+}

--- a/src/main/java/com/example/ballog/domain/match/service/MatchesService.java
+++ b/src/main/java/com/example/ballog/domain/match/service/MatchesService.java
@@ -7,6 +7,7 @@ import com.example.ballog.domain.match.dto.response.MatchesGroupedResponse;
 import com.example.ballog.domain.match.dto.response.MatchesResponse;
 import com.example.ballog.domain.match.dto.response.MatchesWithResponse;
 import com.example.ballog.domain.match.entity.Matches;
+import com.example.ballog.domain.match.entity.Status;
 import com.example.ballog.domain.match.repository.MatchesRepository;
 import com.example.ballog.domain.matchrecord.entity.MatchRecord;
 import com.example.ballog.domain.matchrecord.entity.Result;
@@ -18,10 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -56,13 +54,20 @@ public class MatchesService {
      */
     public Map<String, List<MatchesGroupedResponse>> getAllMatchesGroupedByDate() {
         List<Matches> matchesList = matchesRepository.findAll();
+
+        // Comparator.reverseOrder()로 최신순 TreeMap 생성
         return matchesList.stream()
+                // 날짜+시간 기준 최신순 정렬
+                .sorted(Comparator.comparing(Matches::getMatchesDate).reversed()
+                        .thenComparing(Matches::getMatchesTime).reversed())
+                // 날짜별 그룹화
                 .collect(Collectors.groupingBy(
-                        match -> match.getMatchesDate().toString(),
-                        TreeMap::new,
-                        Collectors.mapping(MatchesGroupedResponse::from, Collectors.toList())
+                        match -> match.getMatchesDate().toString(),         // keyMapper
+                        () -> new TreeMap<String, List<MatchesGroupedResponse>>(Comparator.reverseOrder()), // mapFactory
+                        Collectors.mapping(MatchesGroupedResponse::from, Collectors.toList())              // downstream
                 ));
     }
+
 
     public MatchesResponse getMatchDetail(Long matchId) {
         Matches match = findMatchById(matchId);
@@ -102,6 +107,7 @@ public class MatchesService {
         match.setAwayTeam(request.getAwayTeam());
         match.setStadium(request.getStadium());
         match.setMatchesResult(request.getMatchesResult());
+        match.setStatus(request.getStatus());
         return match;
     }
 
@@ -123,6 +129,10 @@ public class MatchesService {
         }
         if (request.getMatchesResult() != null) {
             match.setMatchesResult(request.getMatchesResult());
+            match.setStatus(Status.COMPLETED); //경기결과 입력 -> 경기 완료
+        }
+        if(request.getStatus() !=null){
+            match.setStatus(request.getStatus());
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-#  port : 8081 #로컬
+#  port : 8080 #로컬
   port : 8082 #서버포트 변경
 
 spring :


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #167 
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 경기 일정 관리
2. 경기 상태 관리
- 경기 결과 입력시 자동으로  경기 상태는 완료로 변경됨
4. 경기 결과 입력
5. 경기 목록 조회(최신순)
