### PR TITLE
feat : 응원팀 전체 감정분포 기능 구현

### DIFF
--- a/src/main/java/com/example/ballog/domain/emotion/repository/EmotionRepository.java
+++ b/src/main/java/com/example/ballog/domain/emotion/repository/EmotionRepository.java
@@ -23,4 +23,6 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
     void deleteAllByUserUserId(@Param("userId") Long userId);
 
     void deleteAllByMatchRecord(MatchRecord matchRecord);
+
+    List<Emotion> findByUser_BaseballTeam(String baseballTeam);
 }

--- a/src/main/java/com/example/ballog/domain/match/repository/MatchesRepository.java
+++ b/src/main/java/com/example/ballog/domain/match/repository/MatchesRepository.java
@@ -25,4 +25,5 @@ public interface MatchesRepository extends JpaRepository<Matches, Long> {
 
     List<Matches> findByMatchesDate(LocalDate matchesDate);
 
+
 }

--- a/src/main/java/com/example/ballog/domain/matchrecord/controller/MatchRecordController.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/controller/MatchRecordController.java
@@ -6,6 +6,7 @@ import com.example.ballog.domain.matchrecord.dto.request.MatchRecordRequest;;
 import com.example.ballog.domain.matchrecord.dto.response.MatchRecordDetailResponse;
 import com.example.ballog.domain.matchrecord.dto.response.MatchRecordListResponse;
 import com.example.ballog.domain.matchrecord.dto.response.MatchRecordResponse;
+import com.example.ballog.domain.matchrecord.dto.response.MatchTeamEmotionResponse;
 import com.example.ballog.domain.matchrecord.service.MatchRecordService;
 import com.example.ballog.global.common.exception.CustomException;
 import com.example.ballog.global.common.exception.enums.ErrorCode;
@@ -69,6 +70,19 @@ public class MatchRecordController {
         MatchRecordDetailResponse response = matchRecordService.getRecordDetailByMatchId(matchId, user);
         return ResponseEntity.ok(BasicResponse.ofSuccess("직관 기록 상세 조회 성공 (matchId 기반)", response));
     }
+
+    @GetMapping("/matches/{matchId}/team")
+    @Operation(summary = "경기 기준 응원팀 또는 경기별 감정 통계 조회")
+    public ResponseEntity<BasicResponse<MatchTeamEmotionResponse>> getTeamEmotionStatsByMatch(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("matchId") Long matchId) {
+
+        User user = getAuthenticatedUser(userDetails);
+        MatchTeamEmotionResponse response = matchRecordService.getTeamEmotionStatsByMatch(matchId, user);
+
+        return ResponseEntity.ok(BasicResponse.ofSuccess("경기 기준 응원팀/감정 통계 조회 성공", response));
+    }
+
 
     @GetMapping
     @Operation(summary = "전체 직관 기록 목록 조회")

--- a/src/main/java/com/example/ballog/domain/matchrecord/dto/response/MatchTeamEmotionResponse.java
+++ b/src/main/java/com/example/ballog/domain/matchrecord/dto/response/MatchTeamEmotionResponse.java
@@ -1,0 +1,33 @@
+package com.example.ballog.domain.matchrecord.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class MatchTeamEmotionResponse {
+    private Long matchId;
+    private String stadium;
+    private String homeTeam;
+    private String awayTeam;
+    private LocalDate matchDate;
+    private LocalTime matchTime;
+
+    private String userTeam;
+
+    //사용자가 팀을 응원하는 경우
+    private Double positiveEmotionPercent;
+    private Double negativeEmotionPercent;
+    private List<EmotionGroupInfo> emotionGroupList;
+
+    //NONE일 경우 (각 팀별)
+    private Double homeTeamPositivePercent;
+    private Double homeTeamNegativePercent;
+    private Double awayTeamPositivePercent;
+    private Double awayTeamNegativePercent;
+}
+


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #175 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

응원팀 전체 감정분포 기능 구현, 응원팀이 `NONE` 일 경우 해당 날짜의 경기 팀의 감정분포 퍼센테이지를 보여준다.
